### PR TITLE
Add Notification Service Extension to project using XcodeGen

### DIFF
--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Notification Service Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -1,0 +1,23 @@
+import UserNotifications
+
+class NotificationService: UNNotificationServiceExtension {
+
+    var contentHandler: ((UNNotificationContent) -> Void)?
+    var bestAttemptContent: UNMutableNotificationContent?
+
+    override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        self.contentHandler = contentHandler
+        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+        
+        if let bestAttemptContent = bestAttemptContent {
+            bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
+            contentHandler(bestAttemptContent)
+        }
+    }
+    
+    override func serviceExtensionTimeWillExpire() {
+        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
+            contentHandler(bestAttemptContent)
+        }
+    }
+}

--- a/Project/Targets/NotificationServiceExtension.yml
+++ b/Project/Targets/NotificationServiceExtension.yml
@@ -1,0 +1,8 @@
+targets:
+  NotificationServiceExtension:
+    platform: iOS
+    type: app-extension
+    sources:
+      - NotificationServiceExtension
+    dependencies:
+      - target: XcodeGen

--- a/Project/targets.yml
+++ b/Project/targets.yml
@@ -2,3 +2,4 @@ include:
   - Targets/XcodeGen.yml
   - Targets/XcodeGenTests.yml
   - Targets/XcodeGenUITests.yml
+  - Targets/NotificationServiceExtension.yml

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # XcodeGen
 
-### Step 7
-All we have done at this step is to organise our `.yml` file so it's easier to reason and code review.
+### Step 8
+We have now added a new Notification Service Extension tarted to the app by simply adding 9 short lines across two `.yml` files.
+
+It is now a lot easier to code review the settings and what the change will bring.
 
 ---
 
 ### Next
-Please now checkout `step-8`
+Please now checkout `step-9`
 
-`git checkout tags/step-8`
+`git checkout tags/step-9`
 
 ---
 


### PR DESCRIPTION
This gives the same result as #1 but adds <NUMBER> less of lines and allows for the code review to highlight the changes rather them hiding in the project file.